### PR TITLE
Fix count erro then select not empty.

### DIFF
--- a/lib/knex-paginator.js
+++ b/lib/knex-paginator.js
@@ -29,7 +29,13 @@ module.exports = function(knex) {
 
         // If the paginator is aware of its length, count the resulting rows
         if (isLengthAware) {
-            promises.push(this.clone().clearSelect().count('* as total').first());
+            var count = this.clone()
+            for(var index in count._statements){
+                if(count._statements[index].joinType != undefined){
+                    count._statements.splice(index, 1)
+                }
+            }
+            promises.push(count.clearSelect().clearOrder().count('* as total').first());
         } else {
             promises.push(new Promise((resolve, reject) => resolve()));
         }
@@ -67,3 +73,4 @@ module.exports = function(knex) {
 		return new KnexQueryBuilder(knex.client);
 	}
 }
+

--- a/lib/knex-paginator.js
+++ b/lib/knex-paginator.js
@@ -29,7 +29,7 @@ module.exports = function(knex) {
 
         // If the paginator is aware of its length, count the resulting rows
         if (isLengthAware) {
-            promises.push(this.clone().count('* as total').first());
+            promises.push(this.clone().clearSelect().count('* as total').first());
         } else {
             promises.push(new Promise((resolve, reject) => resolve()));
         }


### PR DESCRIPTION
Fix count erro then select not empty.
```
knex('mods').debug(true).select(['id', 'name', 'author']).where('index','allow').paginate(10, 1, true)

UnhandledPromiseRejectionWarning: error: column "mods.id" must appear in the GROUP BY clause or be used in an aggregate function
    at Connection.parseE (/home/xausky/Documents/umms/node_modules/pg/lib/connection.js:554:11)
    at Connection.parseMessage (/home/xausky/Documents/umms/node_modules/pg/lib/connection.js:379:19)
    at TLSSocket.<anonymous> (/home/xausky/Documents/umms/node_modules/pg/lib/connection.js:119:22)
    at TLSSocket.emit (events.js:182:13)
    at addChunk (_stream_readable.js:283:12)
    at readableAddChunk (_stream_readable.js:264:11)
    at TLSSocket.Readable.push (_stream_readable.js:219:10)
    at TLSWrap.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
```

this PR fix it.