### PR TITLE
revert "fix error then join" commit

### DIFF
--- a/lib/knex-paginator.js
+++ b/lib/knex-paginator.js
@@ -29,13 +29,7 @@ module.exports = function(knex) {
 
         // If the paginator is aware of its length, count the resulting rows
         if (isLengthAware) {
-            var count = this.clone()
-            for(var index in count._statements){
-                if(count._statements[index].joinType != undefined){
-                    count._statements.splice(index, 1)
-                }
-            }
-            promises.push(count.clearSelect().clearOrder().count('* as total').first());
+            promises.push(this.clone().clearSelect().clearOrder().count('* as total').first());
         } else {
             promises.push(new Promise((resolve, reject) => resolve()));
         }


### PR DESCRIPTION
In the last PR I removed the join block from the Count statement, from a performance perspective, but it caused a problem. such as:
```
await knex('mods').select('mods.id', 'mods.name', 'author.name AS author', 'count', 'viewer', 'update')
            .leftJoin('author', 'mods.author', 'author.id').where(function () {
                this.where('author.name', 'LIKE', '%' + req.query.query + '%').orWhere('mods.name', 'LIKE', '%' + req.query.query + '%')
            }).andWhere('index', 'allow').orderByRaw('count + viewer DESC').paginate(12, page, true);
```
Use join's table in the where statement. An error occurred:
```
error: missing FROM-clause entry for table "author"
    at Connection.parseE (/home/xausky/Documents/umms/node_modules/pg/lib/connection.js:554:11)
    at Connection.parseMessage (/home/xausky/Documents/umms/node_modules/pg/lib/connection.js:379:19)
    at TLSSocket.<anonymous> (/home/xausky/Documents/umms/node_modules/pg/lib/connection.js:119:22)
    at TLSSocket.emit (events.js:182:13)
    at addChunk (_stream_readable.js:283:12)
    at readableAddChunk (_stream_readable.js:264:11)
    at TLSSocket.Readable.push (_stream_readable.js:219:10)
```
So I should revert [that](https://github.com/cannblw/knex-paginator/commit/29b8ff2146f4bf9cbe50a213c200dcc68599df33) commit.