### PR TITLE
faster / less precise query for counting total rows

### DIFF
--- a/lib/knex-paginator.js
+++ b/lib/knex-paginator.js
@@ -1,7 +1,9 @@
 var KnexQueryBuilder = require('knex/lib/query/builder');
 
 module.exports = function (knex) {
-  KnexQueryBuilder.prototype.paginate = function (perPage = 10, page = 1, isLengthAware = false) {
+  KnexQueryBuilder.prototype.paginate = function (perPage = 10, page = 1, isLengthAware = false, preciseCount = true) {
+
+
     // Object that will be returned
     let paginator = {};
 
@@ -29,7 +31,21 @@ module.exports = function (knex) {
 
     // If the paginator is aware of its length, count the resulting rows
     if (isLengthAware) {
-      promises.push(this.clone().clearSelect().clearOrder().count('* as total').first());
+
+    // By default, use a "count" query to get total number of rows
+
+      if (preciseCount) {
+        promises.push(this.clone().clearSelect().clearOrder().count('* as total').first())
+      } else {
+
+    // If count doesn't need to be precise, look up stats table to get an approximation of the total
+    // this._single.table is the name of the queried table
+      promises.push(
+        knex.raw("SELECT n_live_tup FROM pg_stat_user_tables AS total WHERE relname = '"
+          +this._single.table + "';")
+        )
+      }
+
     } else {
       promises.push(new Promise((resolve, _) => resolve()));
     }
@@ -40,7 +56,10 @@ module.exports = function (knex) {
     return Promise.all(promises).then(([countQuery, result]) => {
       // If the paginator is length aware...
       if (isLengthAware) {
-        const total = countQuery.total;
+
+        // if the count is precise, countQuery will have a "total" key
+        // else it will need to be accessed in the object returned by the raw knex query
+        const total = countQuery.total || countQuery.rows[0].n_live_tup;
 
         paginator = {
           ...paginator,


### PR DESCRIPTION
I have added a preciseCount argument, which defaults to true. 
If you need to get a count for a large table and don't require it to be exact, make preciseCount false. 
Based on this article: http://www.dbrnd.com/2015/10/postgresql-fast-way-to-find-the-row-count-of-a-table/ , it queries the pg_stat_user_tables to get an approximate count. This should help speed up queries on larger tables. 

On some occasions, the approximate count is equal to the exact count, on others I have find it to be unfortunately quite inaccurate.
Please bear in mind that I only have a few months experience with PSQL and Node, so my testing hasn't been extensive.


Thanks for the library!