### PR TITLE
Fixed the knex builder path to match the latest knex of knex

### DIFF
--- a/lib/knex-paginator.js
+++ b/lib/knex-paginator.js
@@ -1,4 +1,11 @@
-var KnexQueryBuilder = require('knex/lib/query/builder');
+var KnexQueryBuilder;
+try {
+  // this is the path of the query builder in the latest version of knexjs
+  KnexQueryBuilder = require('knex/src/query/builder');
+} catch(e) {
+  // not found, let's revert to the old path of old version of knexjs
+  KnexQueryBuilder = require('knex/lib/query/builder');
+}
 
 module.exports = function (knex) {
   KnexQueryBuilder.prototype.paginate = function (perPage = 10, page = 1, isLengthAware = false) {


### PR DESCRIPTION
Updated the path of the query builder to match the path in the latest version of knex where lib folder has been renamed to src, with the old path as a fallback.