### PR TITLE
Fix null countQuery on empty set

### DIFF
--- a/lib/knex-paginator.js
+++ b/lib/knex-paginator.js
@@ -47,7 +47,7 @@ module.exports = function (knex) {
     return Promise.all(promises).then(([countQuery, result]) => {
       // If the paginator is length aware...
       if (isLengthAware) {
-        const total = countQuery.total;
+        const total = countQuery == null ? 0 : countQuery.total;
 
         paginator = {
           ...paginator,


### PR DESCRIPTION
If the query returns no result, the `countQuery` will be undefined and throw an error on `lengthAware`.result

Testing environment:
- PostgreSQL 
- Mac OS X
