### PR TITLE
Fixs issue#6

### DIFF
--- a/lib/knex-paginator.js
+++ b/lib/knex-paginator.js
@@ -1,11 +1,20 @@
 var KnexQueryBuilder;
-try {
-  // this is the path of the query builder in the latest version of knexjs
-  KnexQueryBuilder = require('knex/src/query/builder');
-} catch(e) {
-  // not found, let's revert to the old path of old version of knexjs
-  KnexQueryBuilder = require('knex/lib/query/builder');
+try{
+  // check knex is installed in the parent directory
+  require('knex');
+
+  try {
+    // this is the path of the query builder in the latest version of knexjs
+    KnexQueryBuilder = require('knex/src/query/builder');
+  } catch(e) {
+    // not found, let's revert to the old path of old version of knexjs
+    KnexQueryBuilder = require('knex/lib/query/builder');
+  }
 }
+catch(e){
+  console.log(e);
+}
+
 
 module.exports = function (knex) {
   KnexQueryBuilder.prototype.paginate = function (perPage = 10, page = 1, isLengthAware = false) {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
   "bugs": {
     "url": "https://github.com/cannblw/knex-paginator/issues"
   },
-  "homepage": "https://github.com/cannblw/knex-paginator#readme",
-  "dependencies": {
-    "knex": ""
-  }
+  "homepage": "https://github.com/cannblw/knex-paginator#readme"
 }


### PR DESCRIPTION
issue number 6  is happening because paginator is referring its own knex modules . 
I removed the knex dependancy from ``package.json``. Added a try catch block over the existing try catch block for handling knex ``query/builder`` path issue.

first check will check knex is installed in the parent projects